### PR TITLE
Trim the Dockerfile to reduce image size

### DIFF
--- a/3.10.0/Dockerfile
+++ b/3.10.0/Dockerfile
@@ -1,14 +1,15 @@
 FROM registry.centos.org/centos/centos:7
 
 RUN yum -y update && \
-    yum -y install wget
+    yum -y install wget && \
+    yum clean all
 
 ENV MMPP_VERSION 3.10
 ENV MMPP_VERSION_MINOR .0
 
 RUN cd /opt && \
     wget https://github.com/mattermost/mattermost-push-proxy/releases/download/v${MMPP_VERSION}/mattermost-push-proxy-${MMPP_VERSION}${MMPP_VERSION_MINOR}.tar.gz && \
-    tar xvf mattermost-push-proxy-${MMPP_VERSION}${MMPP_VERSION_MINOR}.tar.gz
+    tar xvf mattermost-push-proxy-${MMPP_VERSION}${MMPP_VERSION_MINOR}.tar.gz && rm mattermost-push-proxy-${MMPP_VERSION}${MMPP_VERSION_MINOR}.tar.gz
 
 COPY mattermost-push-proxy.json /opt/mattermost-push-proxy/
 
@@ -17,4 +18,3 @@ RUN chmod 777 /opt/mattermost-push-proxy/mattermost-push-proxy.json
 COPY docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-


### PR DESCRIPTION
Clean up yum cache.
Remove the source tar after extraction while building image.

With original Dockerfile:
```
mm-push-proxy                       3.10.0              2e8420cf11e4        About a minute ago   324.5 MB
```
Build with trimmed dockerfile:
```
mm-pp-trimmed-1                     latest              1bceae099f61        9 seconds ago       262.5 MB
```